### PR TITLE
Add subdivisions of Bolivia

### DIFF
--- a/listo.php
+++ b/listo.php
@@ -30,6 +30,7 @@ class Listo_Manager {
 		$list_types = array(
 			'countries' => 'Listo_Countries',
 			'ar_subdivisions' => 'Listo_AR_Subdivisions',
+			'bo_subdivisions' => 'Listo_BO_Subdivisions',
 			'br_subdivisions' => 'Listo_BR_Subdivisions',
 			'in_subdivisions' => 'Listo_IN_Subdivisions',
 			'us_subdivisions' => 'Listo_US_Subdivisions',

--- a/modules/bo-subdivisions.php
+++ b/modules/bo-subdivisions.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * The list of subdivisions of Bolivia based on ISO 3166-2:BO standard.
+ *
+ * Source: https://en.wikipedia.org/wiki/ISO_3166-2:BO ISO 3166-2:BO
+ */
+class Listo_BO_Subdivisions implements Listo {
+	private function __construct() {}
+
+	public static function items() {
+		return array(
+			'c' => _x( 'Cochabamba', 'bo_subdivisions', 'listo' ),
+			'h' => _x( 'Chuquisaca', 'bo_subdivisions', 'listo' ),
+			'b' => _x( 'El Beni', 'bo_subdivisions', 'listo' ),
+			'l' => _x( 'La Paz', 'bo_subdivisions', 'listo' ),
+			'o' => _x( 'Oruro', 'bo_subdivisions', 'listo' ),
+			'n' => _x( 'Pando', 'bo_subdivisions', 'listo' ),
+			'p' => _x( 'Potosí', 'bo_subdivisions', 'listo' ),
+			's' => _x( 'Santa Cruz', 'bo_subdivisions', 'listo' ),
+			't' => _x( 'Tarija', 'bo_subdivisions', 'listo' ),
+		);
+	}
+
+	public static function groups() {
+		return array();
+	}
+}


### PR DESCRIPTION
The list of subdivisions of Bolivia based on ISO 3166-2:BO standard.

Source: https://en.wikipedia.org/wiki/ISO_3166-2:BO ISO 3166-2:BO

(Issued: #1)