### PR TITLE
Add subdivisions of Chile

### DIFF
--- a/listo.php
+++ b/listo.php
@@ -32,6 +32,7 @@ class Listo_Manager {
 			'ar_subdivisions' => 'Listo_AR_Subdivisions',
 			'bo_subdivisions' => 'Listo_BO_Subdivisions',
 			'br_subdivisions' => 'Listo_BR_Subdivisions',
+			'cl_subdivisions' => 'Listo_CL_Subdivisions',
 			'in_subdivisions' => 'Listo_IN_Subdivisions',
 			'us_subdivisions' => 'Listo_US_Subdivisions',
 			've_subdivisions' => 'Listo_VE_Subdivisions',

--- a/modules/cl-subdivisions.php
+++ b/modules/cl-subdivisions.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * The list of subdivisions of Chile based on ISO 3166-2:CL standard.
+ *
+ * Source: https://en.wikipedia.org/wiki/ISO_3166-2:CL ISO 3166-2:CL
+ */
+class Listo_CL_Subdivisions implements Listo {
+	private function __construct() {}
+
+	public static function items() {
+		return array(
+			'ai' => _x( 'Aisén del General Carlos Ibañez del Campo', 'cl_subdivisions', 'listo' ),
+			'an' => _x( 'Antofagasta', 'cl_subdivisions', 'listo' ),
+			'ap' => _x( 'Arica y Parinacota', 'cl_subdivisions', 'listo' ),
+			'at' => _x( 'Atacama', 'cl_subdivisions', 'listo' ),
+			'bi' => _x( 'Biobío', 'cl_subdivisions', 'listo' ),
+			'co' => _x( 'Coquimbo', 'cl_subdivisions', 'listo' ),
+			'ar' => _x( 'La Araucanía', 'cl_subdivisions', 'listo' ),
+			'li' => _x( 'Libertador General Bernardo O\'Higgins', 'cl_subdivisions', 'listo' ),
+			'll' => _x( 'Los Lagos', 'cl_subdivisions', 'listo' ),
+			'lr' => _x( 'Los Ríos', 'cl_subdivisions', 'listo' ),
+			'ma' => _x( 'Magallanes', 'cl_subdivisions', 'listo' ),
+			'ml' => _x( 'Maule', 'cl_subdivisions', 'listo' ),
+			'nb' => _x( 'Ñuble', 'cl_subdivisions', 'listo' ),
+			'rm' => _x( 'Región Metropolitana de Santiago', 'cl_subdivisions', 'listo' ),
+			'ta' => _x( 'Tarapacá', 'cl_subdivisions', 'listo' ),
+			'vs' => _x( 'Valparaíso', 'cl_subdivisions', 'listo' ),
+		);
+	}
+
+	public static function groups() {
+		return array();
+	}
+}


### PR DESCRIPTION
The list of subdivisions of Chile based on ISO 3166-2:CL standard.

Source: https://en.wikipedia.org/wiki/ISO_3166-2:CL ISO 3166-2:CL

(Issued: #1)