### PR TITLE
Add subdivisions of Costa Rica

### DIFF
--- a/listo.php
+++ b/listo.php
@@ -34,6 +34,7 @@ class Listo_Manager {
 			'br_subdivisions' => 'Listo_BR_Subdivisions',
 			'cl_subdivisions' => 'Listo_CL_Subdivisions',
 			'co_subdivisions' => 'Listo_CO_Subdivisions',
+			'cr_subdivisions' => 'Listo_CR_Subdivisions',
 			'in_subdivisions' => 'Listo_IN_Subdivisions',
 			'us_subdivisions' => 'Listo_US_Subdivisions',
 			've_subdivisions' => 'Listo_VE_Subdivisions',

--- a/modules/cr-subdivisions.php
+++ b/modules/cr-subdivisions.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * The list of subdivisions of Costa Rica based on ISO 3166-2:CR standard.
+ *
+ * Source: https://en.wikipedia.org/wiki/ISO_3166-2:CR ISO 3166-2:CR
+ */
+class Listo_CR_Subdivisions implements Listo {
+	private function __construct() {}
+
+	public static function items() {
+		return array(
+			'a' => _x( 'Alajuela', 'cr_subdivisions', 'listo' ),
+			'c' => _x( 'Cartago', 'cr_subdivisions', 'listo' ),
+			'g' => _x( 'Guanacaste', 'cr_subdivisions', 'listo' ),
+			'h' => _x( 'Heredia', 'cr_subdivisions', 'listo' ),
+			'l' => _x( 'Limón', 'cr_subdivisions', 'listo' ),
+			'p' => _x( 'Puntarenas', 'cr_subdivisions', 'listo' ),
+			'sj' => _x( 'San José', 'cr_subdivisions', 'listo' ),
+		);
+	}
+
+	public static function groups() {
+		return array();
+	}
+}


### PR DESCRIPTION
The list of subdivisions of Costa Rica based on ISO 3166-2:CR standard.

Source: https://en.wikipedia.org/wiki/ISO_3166-2:CR ISO 3166-2:CR

(Issued: #1)