### PR TITLE
Add subdivisions of Haiti

### DIFF
--- a/listo.php
+++ b/listo.php
@@ -38,6 +38,7 @@ class Listo_Manager {
 			'cu_subdivisions' => 'Listo_CU_Subdivisions',
 			'ec_subdivisions' => 'Listo_EC_Subdivisions',
 			'gt_subdivisions' => 'Listo_GT_Subdivisions',
+			'ht_subdivisions' => 'Listo_HT_Subdivisions',
 			'in_subdivisions' => 'Listo_IN_Subdivisions',
 			'sv_subdivisions' => 'Listo_SV_Subdivisions',
 			'us_subdivisions' => 'Listo_US_Subdivisions',

--- a/modules/ht-subdivisions.php
+++ b/modules/ht-subdivisions.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * The list of subdivisions of Haiti based on ISO 3166-2:HT standard.
+ *
+ * Source: https://en.wikipedia.org/wiki/ISO_3166-2:HT ISO 3166-2:HT
+ */
+class Listo_HT_Subdivisions implements Listo {
+	private function __construct() {}
+
+	public static function items() {
+		return array(
+			'ar' => _x( 'Artibonite', 'ht_subdivisions', 'listo' ),
+			'ce' => _x( 'Centre', 'ht_subdivisions', 'listo' ),
+			'ga' => _x( 'Grande’Anse', 'ht_subdivisions', 'listo' ),
+			'ni' => _x( 'Nippes', 'ht_subdivisions', 'listo' ),
+			'nd' => _x( 'Nord', 'ht_subdivisions', 'listo' ),
+			'ne' => _x( 'Nord-Est', 'ht_subdivisions', 'listo' ),
+			'no' => _x( 'Nord-Ouest', 'ht_subdivisions', 'listo' ),
+			'ou' => _x( 'Ouest', 'ht_subdivisions', 'listo' ),
+			'sd' => _x( 'Sud', 'ht_subdivisions', 'listo' ),
+			'se' => _x( 'Sud-Est', 'ht_subdivisions', 'listo' ),
+		);
+	}
+
+	public static function groups() {
+		return array();
+	}
+}


### PR DESCRIPTION
The list of subdivisions of Haiti based on ISO 3166-2:HT standard.

Source: https://en.wikipedia.org/wiki/ISO_3166-2:HT ISO 3166-2:HT

(Issued: #1)