### PR TITLE
Add subdivisions of Honduras

### DIFF
--- a/listo.php
+++ b/listo.php
@@ -38,6 +38,7 @@ class Listo_Manager {
 			'cu_subdivisions' => 'Listo_CU_Subdivisions',
 			'ec_subdivisions' => 'Listo_EC_Subdivisions',
 			'gt_subdivisions' => 'Listo_GT_Subdivisions',
+			'hn_subdivisions' => 'Listo_HN_Subdivisions',
 			'ht_subdivisions' => 'Listo_HT_Subdivisions',
 			'in_subdivisions' => 'Listo_IN_Subdivisions',
 			'sv_subdivisions' => 'Listo_SV_Subdivisions',

--- a/modules/hn-subdivisions.php
+++ b/modules/hn-subdivisions.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * The list of subdivisions of Honduras based on ISO 3166-2:HN standard.
+ *
+ * Source: https://en.wikipedia.org/wiki/ISO_3166-2:HN ISO 3166-2:HN
+ */
+class Listo_HN_Subdivisions implements Listo {
+	private function __construct() {}
+
+	public static function items() {
+		return array(
+			'at' => _x( 'Atlántida', 'hn_subdivisions', 'listo' ),
+			'ch' => _x( 'Choluteca', 'hn_subdivisions', 'listo' ),
+			'cl' => _x( 'Colón', 'hn_subdivisions', 'listo' ),
+			'cm' => _x( 'Comayagua', 'hn_subdivisions', 'listo' ),
+			'cp' => _x( 'Copán', 'hn_subdivisions', 'listo' ),
+			'cr' => _x( 'Cortés', 'hn_subdivisions', 'listo' ),
+			'ep' => _x( 'El Paraíso', 'hn_subdivisions', 'listo' ),
+			'fm' => _x( 'Francisco Morazán', 'hn_subdivisions', 'listo' ),
+			'gd' => _x( 'Gracias a Dios', 'hn_subdivisions', 'listo' ),
+			'in' => _x( 'Intibucá', 'hn_subdivisions', 'listo' ),
+			'ib' => _x( 'Islas de la Bahía', 'hn_subdivisions', 'listo' ),
+			'lp' => _x( 'La Paz', 'hn_subdivisions', 'listo' ),
+			'le' => _x( 'Lempira', 'hn_subdivisions', 'listo' ),
+			'oc' => _x( 'Ocotepeque', 'hn_subdivisions', 'listo' ),
+			'ol' => _x( 'Olancho', 'hn_subdivisions', 'listo' ),
+			'sb' => _x( 'Santa Bárbara', 'hn_subdivisions', 'listo' ),
+			'va' => _x( 'Valle', 'hn_subdivisions', 'listo' ),
+			'yo' => _x( 'Yoro', 'hn_subdivisions', 'listo' ),
+		);
+	}
+
+	public static function groups() {
+		return array();
+	}
+}


### PR DESCRIPTION
The list of subdivisions of Honduras based on ISO 3166-2:HN standard.

Source: https://en.wikipedia.org/wiki/ISO_3166-2:HN ISO 3166-2:HN

(Issued: #1)