### PR TITLE
Add subdivisions of Panama

### DIFF
--- a/listo.php
+++ b/listo.php
@@ -43,6 +43,7 @@ class Listo_Manager {
 			'in_subdivisions' => 'Listo_IN_Subdivisions',
 			'mx_subdivisions' => 'Listo_MX_Subdivisions',
 			'ni_subdivisions' => 'Listo_NI_Subdivisions',
+			'pa_subdivisions' => 'Listo_PA_Subdivisions',
 			'sv_subdivisions' => 'Listo_SV_Subdivisions',
 			'us_subdivisions' => 'Listo_US_Subdivisions',
 			've_subdivisions' => 'Listo_VE_Subdivisions',

--- a/modules/pa-subdivisions.php
+++ b/modules/pa-subdivisions.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * The list of subdivisions of Panama based on ISO 3166-2:PA standard.
+ *
+ * Source: https://en.wikipedia.org/wiki/ISO_3166-2:PA ISO 3166-2:PA
+ */
+class Listo_PA_Subdivisions implements Listo {
+	private function __construct() {}
+
+	public static function items() {
+		return array(
+			'1' => _x( 'Bocas del Toro', 'pa_subdivisions', 'listo' ),
+			'4' => _x( 'Chiriquí', 'pa_subdivisions', 'listo' ),
+			'2' => _x( 'Coclé', 'pa_subdivisions', 'listo' ),
+			'3' => _x( 'Colón', 'pa_subdivisions', 'listo' ),
+			'5' => _x( 'Darién', 'pa_subdivisions', 'listo' ),
+			'em' => _x( 'Emberá', 'pa_subdivisions', 'listo' ),
+			'ky' => _x( 'Guna Yala', 'pa_subdivisions', 'listo' ),
+			'6' => _x( 'Herrera', 'pa_subdivisions', 'listo' ),
+			'7' => _x( 'Los Santos', 'pa_subdivisions', 'listo' ),
+			'nb' => _x( 'Ngöbe-Buglé', 'pa_subdivisions', 'listo' ),
+			'8' => _x( 'Panamá', 'pa_subdivisions', 'listo' ),
+			'10' => _x( 'Panamá Oeste', 'pa_subdivisions', 'listo' ),
+			'9' => _x( 'Veraguas', 'pa_subdivisions', 'listo' ),
+		);
+	}
+
+	public static function groups() {
+		return array(
+			'provinces' => array( '1', '4', '2', '3', '5', '6', '7', '8', '10', '9',),
+			'indigenous_regions' => array( 'em', 'ky', 'nb' ),
+		);
+	}
+}

--- a/modules/pa-subdivisions.php
+++ b/modules/pa-subdivisions.php
@@ -27,7 +27,7 @@ class Listo_PA_Subdivisions implements Listo {
 
 	public static function groups() {
 		return array(
-			'provinces' => array( '1', '4', '2', '3', '5', '6', '7', '8', '10', '9',),
+			'provinces' => array( '1', '4', '2', '3', '5', '6', '7', '8', '10', '9' ),
 			'indigenous_regions' => array( 'em', 'ky', 'nb' ),
 		);
 	}


### PR DESCRIPTION
The list of subdivisions of Panama based on ISO 3166-2:PA standard.

Source: https://en.wikipedia.org/wiki/ISO_3166-2:PA ISO 3166-2:PA

(Issued: #1)